### PR TITLE
Have the broker accept an undefined SC in its configuration and pass it through to the PVC.

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -233,9 +233,9 @@ func (b *KubeVolumeBroker) Bind(ctx context.Context, instanceID, bindingID strin
 	}
 
 	storageClassName := *pvc.Spec.StorageClassName
-	spec.Credentials =  map[string]interface{}{
+	spec.Credentials = map[string]interface{}{
 		"volume_id": pvc.Name,
-}
+	}
 	spec.VolumeMounts = []brokerapi.VolumeMount{
 		{
 			Driver:       storageClassName,
@@ -243,7 +243,7 @@ func (b *KubeVolumeBroker) Bind(ctx context.Context, instanceID, bindingID strin
 			Mode:         "rw",
 			DeviceType:   "shared",
 			Device: brokerapi.SharedDevice{
-				VolumeId:    pvc.Name,
+				VolumeId: pvc.Name,
 			},
 		},
 	}

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -139,7 +139,7 @@ func (b *KubeVolumeBroker) Provision(ctx context.Context, instanceID string, ser
 			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
-			StorageClassName: &plan.StorageClass,
+			StorageClassName: plan.StorageClass,
 			AccessModes: []corev1.PersistentVolumeAccessMode{
 				"ReadWriteOnce",
 			},

--- a/broker/catalog_test.go
+++ b/broker/catalog_test.go
@@ -39,7 +39,7 @@ func DefaultPlanConfiguration() config.Plan {
 
 		ID:           DefaultPlanID,
 		Name:         DefaultPlanName,
-		StorageClass: DefaultStorageClass,
+		StorageClass: &DefaultStorageClass,
 		Free:         true,
 		DefaultSize:  "1Gi",
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -39,12 +39,12 @@ type ServiceConfiguration struct {
 
 // Plan represents a Broker plan for a Kubernetes storage class
 type Plan struct {
-	ID           string `yaml:"plan_id"`
-	Name         string `yaml:"plan_name"`
-	Description  string `yaml:"description"`
+	ID           string  `yaml:"plan_id"`
+	Name         string  `yaml:"plan_name"`
+	Description  string  `yaml:"description"`
 	StorageClass *string `yaml:"kube_storage_class"`
-	Free         bool   `yaml:"free"`
-	DefaultSize  string `yaml:"default_size"`
+	Free         bool    `yaml:"free"`
+	DefaultSize  string  `yaml:"default_size"`
 }
 
 // ParseConfig parses a config file

--- a/config/config.go
+++ b/config/config.go
@@ -42,7 +42,7 @@ type Plan struct {
 	ID           string `yaml:"plan_id"`
 	Name         string `yaml:"plan_name"`
 	Description  string `yaml:"description"`
-	StorageClass string `yaml:"kube_storage_class"`
+	StorageClass *string `yaml:"kube_storage_class"`
 	Free         bool   `yaml:"free"`
 	DefaultSize  string `yaml:"default_size"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -71,19 +71,21 @@ var _ = Describe("parsing the broker config file", func() {
 			})
 
 			It("loads plans", func() {
+				persistent := "persistent"
+				gold := "gold"
 				Ω(config.ServiceConfiguration.Plans).To(BeEquivalentTo(
 					[]brokerconfig.Plan{
 						{
 							Name:         "somename",
 							ID:           "someid",
-							StorageClass: "persistent",
+							StorageClass: &persistent,
 							Free:         true,
 							Description:  "this is a description",
 						},
 						{
 							Name:         "someothername",
 							ID:           "someotherid",
-							StorageClass: "gold",
+							StorageClass: &gold,
 							Free:         false,
 							Description:  "this is another description",
 						},


### PR DESCRIPTION
See https://github.com/cloudfoundry-incubator/kubecf/issues/819

By not specifying an SC we can make use of the DefaultSC admission plugin
to get something sensible in a more complex deployment with many helm charts
and sub charts.


# Testing

This pull request is one in a group of 3 related PRs.
They have to be reviewed and tested together.
The instructions for such are found at https://github.com/cloudfoundry-incubator/kubecf/issues/819#issuecomment-649841863
The full set of PRs is listed in the description of https://github.com/cloudfoundry-incubator/kubecf/issues/819
